### PR TITLE
fix(aws): Preserve origin authorization header.

### DIFF
--- a/aws/cloudfront/module/main.tf
+++ b/aws/cloudfront/module/main.tf
@@ -258,7 +258,6 @@ resource "aws_cloudfront_cache_policy" "default_cache_policy" {
       # Cache reasonable headers (with the exception of the Host header as serverless platforms we use do not support it)
       headers {
         items = [
-          "Authorization",
           "x-method-override",
           "origin",
           "x-http-method",

--- a/aws/cloudfront/module/scripts/url-rewrite.js
+++ b/aws/cloudfront/module/scripts/url-rewrite.js
@@ -6,6 +6,13 @@ var allBasePaths = basePaths.split(",").sort((a, b) => b.length - a.length);
 function handler(event) {
   var request = event.request;
   var uri = request.uri;
+    
+  // Preserve auth header for lambdas and other OAC dependent services
+  if (request.headers['authorization']) {
+      request.headers['x-forwarded-auth'] = {
+          value: request.headers['authorization'].value
+      };
+  }
 
   for (var i = 0; i < allBasePaths.length; i++) {
     if (allBasePaths[i] === "/") {

--- a/aws/lambda/awslambda.go
+++ b/aws/lambda/awslambda.go
@@ -81,6 +81,11 @@ func (a *awslambdaService) handleHTTPEvent(ctx context.Context, evt *events.Lamb
 		req.Header.Add(k, v)
 	}
 
+	// Preserve auth header for lambdas and other OAC dependent services
+	if evt.Headers["X-Forwarded-Auth"] != "" {
+		req.Header.Add("Authorization", evt.Headers["X-Forwarded-Auth"])
+	}
+
 	req.URL.RawQuery = evt.RawQueryString
 
 	resp, err := a.proxy.Forward(ctx, req)


### PR DESCRIPTION
This should send the Authorization header through. Users should set no cache headers for auth routes.